### PR TITLE
Issue #6: Replace require_user_key_login with actual session

### DIFF
--- a/classes/converter.php
+++ b/classes/converter.php
@@ -48,8 +48,7 @@ abstract class converter {
     /**
      * Generate the PDF content of a target URL passed through proxy URL.
      *
-     * @param \moodle_url $proxyurl the plugin proxy url for access key login and redirection to target URL
-     * {@link /admin/tool/pages/index.php}.
+     * @param \moodle_url $proxyurl the plugin proxy url for access key login and redirection to target URL.
      * @param string $filename the name to give converted file.
      * @param array $options any additional options to pass to converter, valid options vary with converter
      * instance, see relevant converter for further details.

--- a/classes/converter.php
+++ b/classes/converter.php
@@ -25,7 +25,6 @@
 
 namespace tool_pdfpages;
 
-use Matrix\Exception;
 use moodle_url;
 
 defined('MOODLE_INTERNAL') || die();
@@ -57,12 +56,8 @@ abstract class converter {
      *
      * @return string raw PDF content of URL.
      */
-    protected function generate_pdf_content(moodle_url $proxyurl, string $filename = '', array $options = [],
-                               string $cookiename = '', string $cookievalue = ''): string {
-        // Implement converter specific logic for URL PDF extraction here.
-        // The HTTP/HTTPS client used in conversion must support redirection and redirection must be implemented,
-        // otherwise the proxy pass-through will not work.
-    }
+    abstract protected function generate_pdf_content(moodle_url $proxyurl, string $filename = '', array $options = [],
+                               string $cookiename = '', string $cookievalue = ''): string;
 
     /**
      * Convert a moodle URL to PDF and store in file system.

--- a/classes/converter.php
+++ b/classes/converter.php
@@ -67,6 +67,10 @@ abstract class converter {
         // When implemented, the target URL must be passed through the proxy page (index.php) as a parameter
         // along with the access key, in order to validate user login.
         // {@see \tool_pdfpages\helper::get_proxy_url}.
+
+        // All converters MUST implement `destroy session` following conversion, in order to prevent improper use
+        // of the session for further actions.
+        $this->destroy_session();
     }
 
     /**
@@ -90,6 +94,13 @@ abstract class converter {
         }
 
         return $fs->create_file_from_string($filerecord, $content);
+    }
+
+    /**
+     * Destroy the current session.
+     */
+    protected function destroy_session(): void {
+        \core\session\manager::terminate_current();
     }
 
     /**

--- a/classes/converter_chromium.php
+++ b/classes/converter_chromium.php
@@ -72,8 +72,7 @@ class converter_chromium extends converter {
     /**
      * Generate the PDF content of a target URL passed through proxy URL.
      *
-     * @param \moodle_url $proxyurl the plugin proxy url for access key login and redirection to target URL
-     * {@link /admin/tool/pages/index.php}.
+     * @param \moodle_url $proxyurl the plugin proxy url for access key login and redirection to target URL.
      * @param string $filename the name to give converted file.
      * @param array $options any additional options to pass to converter, valid options vary with converter
      * instance, see relevant converter for further details.

--- a/classes/converter_chromium.php
+++ b/classes/converter_chromium.php
@@ -125,6 +125,9 @@ class converter_chromium extends converter {
             if (!empty($browser) && $browser instanceof Browser) {
                 $browser->close();
             }
+
+            // Destroy the session to prevent token login session hijacking.
+            $this->destroy_session();
         }
     }
 

--- a/classes/converter_wkhtmltopdf.php
+++ b/classes/converter_wkhtmltopdf.php
@@ -230,6 +230,9 @@ class converter_wkhtmltopdf extends converter {
 
         } catch (\Exception $exception) {
             throw new \moodle_exception('error:urltopdf', 'tool_pdfpages', '', null, $exception->getMessage());
+        } finally {
+            // Destroy the session to prevent token login session hijacking.
+            $this->destroy_session();
         }
     }
 

--- a/classes/converter_wkhtmltopdf.php
+++ b/classes/converter_wkhtmltopdf.php
@@ -201,6 +201,8 @@ class converter_wkhtmltopdf extends converter {
      */
     protected function generate_pdf_content(moodle_url $proxyurl, string $filename = '', array $options = [],
                                               string $cookiename = '', string $cookievalue = ''): string {
+        $this->validate_options($options);
+
         $pdf = new Pdf(helper::get_config($this->get_name() . 'path'));
         $pdf->setOptions($options);
 

--- a/classes/converter_wkhtmltopdf.php
+++ b/classes/converter_wkhtmltopdf.php
@@ -190,8 +190,7 @@ class converter_wkhtmltopdf extends converter {
     /**
      * Generate the PDF content of a target URL passed through proxy URL.
      *
-     * @param \moodle_url $proxyurl the plugin proxy url for access key login and redirection to target URL
-     * {@link /admin/tool/pages/index.php}.
+     * @param \moodle_url $proxyurl the plugin proxy url for access key login and redirection to target URL.
      * @param string $filename the name to give converted file.
      * @param array $options any additional options to pass to converter, valid options vary with converter
      * instance, see relevant converter for further details.

--- a/index.php
+++ b/index.php
@@ -27,21 +27,15 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-define('NO_MOODLE_COOKIES', true); // No need for a session here.
+use tool_pdfpages\helper;
 
 require_once(__DIR__ . '/../../../config.php');
-
-global $CFG;
 
 $targeturl = required_param('url', PARAM_URL);
 $key = required_param('key', PARAM_ALPHANUM);
 
 $url = new moodle_url($targeturl);
 
-require_user_key_login('tool/pdfpages');
+helper::login_with_key($key);
 
-foreach ($url->params() as $param => $value) {
-    $_GET[$param] = $value;
-}
-
-require($CFG->dirroot . $url->get_path());
+redirect($url);

--- a/tests/converter_chromium_test.php
+++ b/tests/converter_chromium_test.php
@@ -24,7 +24,6 @@
  */
 
 use tool_pdfpages\converter_chromium;
-use tool_pdfpages\helper;
 
 defined('MOODLE_INTERNAL') || die();
 

--- a/tests/converter_test.php
+++ b/tests/converter_test.php
@@ -1,0 +1,89 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Abstract converter class tests for tool_pdfpages.
+ *
+ * @package    tool_pdfpages
+ * @author     Tom Dickman <tomdickman@catalyst-au.net>
+ * @copyright  2021 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+use tool_pdfpages\converter;
+use tool_pdfpages\helper;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Abstract converter class tests for tool_pdfpages.
+ *
+ * @package    tool_pdfpages
+ * @author     Tom Dickman <tomdickman@catalyst-au.net>
+ * @copyright  2021 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class converter_test extends advanced_testcase {
+
+    /**
+     * Test that converter always destroys access key session after conversion.
+     */
+    public function test_convert_moodle_url_to_pdf_session_termination() {
+        global $SESSION, $USER;
+
+        $this->resetAfterTest();
+
+        $user = $this->getDataGenerator()->create_user();
+        $this->setUser($user);
+
+        // Create the key and log user in with access key.
+        $key = helper::create_user_key();
+        helper::login_with_key($key);
+
+        // Check that session is created for logged in user before conversion.
+        $this->assertEquals($user->id, $USER->id);
+        $this->assertEquals($user->id, $_SESSION['USER']->id);
+
+        $mock = $this->createMock(converter::class);
+
+        // Mock the abstract PDF generation method.
+        $pdfcontent = 'Test PDF content';
+        $mock->method('generate_pdf_content')
+            ->willReturn($pdfcontent);
+
+        // Mock the PDF file creation.
+        $filerecord = [
+            'contextid' => \context_system::instance()->id,
+            'component' => 'tool_pdfpages',
+            'filearea' => 'pdf',
+            'itemid' => 0,
+            'filepath' => "/base/",
+            'filename' => 'test.pdf'
+        ];
+        $fs = get_file_storage();
+        $file = $fs->create_file_from_string($filerecord, $pdfcontent);
+        $mock->method('create_pdf_file')
+            ->willReturn($file);
+
+        $url = new moodle_url('/');
+        $mock->convert_moodle_url_to_pdf($url, $key);
+
+        // User session should be destroyed following conversion.
+        $this->assertEquals(0, $USER->id);
+        $this->assertEmpty((array) $SESSION);
+        $this->assertEquals(0, $_SESSION['USER']->id);
+    }
+}


### PR DESCRIPTION
The previous iteration used `require_user_key_login` to validate
user access key, this means that no real session was created and
the target URL script was imported via `require` which could
lead to errors if import scripts in target script are relative.

Remove `require_user_key_login` use and manually validate the
token before setting session user and then redirecting to the
target URL.