### PR TITLE
Issue #23: Prevent race conditions

### DIFF
--- a/classes/converter.php
+++ b/classes/converter.php
@@ -79,9 +79,9 @@ abstract class converter {
 
         try {
             $filename = ($filename === '') ? helper::get_moodle_url_pdf_filename($url) : $filename;
-            $instanceid = key_manager::get_instance_id($filename);
-            $key = key_manager::create_user_key($instanceid);
-            $proxyurl = helper::get_proxy_url($url, $key, $instanceid);
+            $instance = key_manager::generate_instance($filename);
+            $key = key_manager::create_user_key($instance);
+            $proxyurl = helper::get_proxy_url($url, $key, $instance);
             $content = $this->generate_pdf_content($proxyurl, $filename, $options, $cookiename, $cookievalue);
 
             return $this->create_pdf_file($content, $filename);

--- a/classes/converter.php
+++ b/classes/converter.php
@@ -76,11 +76,12 @@ abstract class converter {
      */
     final public function convert_moodle_url_to_pdf(moodle_url $url, string $filename = '', array $options = [],
                                               string $cookiename = '', string $cookievalue = ''): \stored_file {
+        global $USER;
 
         try {
             $filename = ($filename === '') ? helper::get_moodle_url_pdf_filename($url) : $filename;
             $instance = key_manager::generate_instance($filename);
-            $key = key_manager::create_user_key($instance);
+            $key = key_manager::create_user_key($USER->id, $instance);
             $proxyurl = helper::get_proxy_url($url, $key, $instance);
             $content = $this->generate_pdf_content($proxyurl, $filename, $options, $cookiename, $cookievalue);
 

--- a/classes/converter.php
+++ b/classes/converter.php
@@ -76,9 +76,11 @@ abstract class converter {
      */
     final public function convert_moodle_url_to_pdf(moodle_url $url, string $filename = '', array $options = [],
                                               string $cookiename = '', string $cookievalue = ''): \stored_file {
+        global $USER;
+
         try {
             $filename = ($filename === '') ? helper::get_moodle_url_pdf_filename($url) : $filename;
-            $key = key_manager::create_user_key_for_url($url);
+            $key = key_manager::create_user_key_for_url($USER->id, $url);
             $proxyurl = helper::get_proxy_url($url, $key);
             $content = $this->generate_pdf_content($proxyurl, $filename, $options, $cookiename, $cookievalue);
 

--- a/classes/converter.php
+++ b/classes/converter.php
@@ -78,9 +78,10 @@ abstract class converter {
                                               string $cookiename = '', string $cookievalue = ''): \stored_file {
 
         try {
-            $key = helper::create_user_key();
-            $proxyurl = helper::get_proxy_url($url, $key);
             $filename = ($filename === '') ? helper::get_moodle_url_pdf_filename($url) : $filename;
+            $instanceid = key_manager::get_instance_id($filename);
+            $key = key_manager::create_user_key($instanceid);
+            $proxyurl = helper::get_proxy_url($url, $key, $instanceid);
             $content = $this->generate_pdf_content($proxyurl, $filename, $options, $cookiename, $cookievalue);
 
             return $this->create_pdf_file($content, $filename);

--- a/classes/converter.php
+++ b/classes/converter.php
@@ -76,13 +76,10 @@ abstract class converter {
      */
     final public function convert_moodle_url_to_pdf(moodle_url $url, string $filename = '', array $options = [],
                                               string $cookiename = '', string $cookievalue = ''): \stored_file {
-        global $USER;
-
         try {
             $filename = ($filename === '') ? helper::get_moodle_url_pdf_filename($url) : $filename;
-            $instance = key_manager::generate_instance($filename);
-            $key = key_manager::create_user_key($USER->id, $instance);
-            $proxyurl = helper::get_proxy_url($url, $key, $instance);
+            $key = key_manager::create_user_key_for_url($url);
+            $proxyurl = helper::get_proxy_url($url, $key);
             $content = $this->generate_pdf_content($proxyurl, $filename, $options, $cookiename, $cookievalue);
 
             return $this->create_pdf_file($content, $filename);

--- a/classes/helper.php
+++ b/classes/helper.php
@@ -135,15 +135,13 @@ class helper {
      *
      * @param \moodle_url $targeturl the target URL to reach after passing through proxy.
      * @param string $key the access key to use for Moodle user login validation.
-     * @param int $instance the instance to use for access key. {@see \tool_pdfpages\key_manager::generate_instance}.
      *
      * @return \moodle_url
      */
-    public static function get_proxy_url(moodle_url $targeturl, string $key, int $instance) {
+    public static function get_proxy_url(moodle_url $targeturl, string $key) {
         $params = [
             'url' => $targeturl->out(),
             'key' => $key,
-            'instance' => $instance
         ];
 
         return new moodle_url(self::PROXY_URL, $params);

--- a/classes/helper.php
+++ b/classes/helper.php
@@ -49,6 +49,11 @@ class helper {
     const MOODLE_URL_PDF_FILEAREA = 'pdf';
 
     /**
+     * The proxy URL to pass conversions through.
+     */
+    const PROXY_URL = '/admin/tool/pdfpages/index.php';
+
+    /**
      * List of available converters.
      *
      * To add a new converter, the following steps need to be conducted:
@@ -141,7 +146,7 @@ class helper {
             'instance' => $instance
         ];
 
-        return new moodle_url('/admin/tool/pdfpages/index.php', $params);
+        return new moodle_url(self::PROXY_URL, $params);
     }
 
     /**

--- a/classes/helper.php
+++ b/classes/helper.php
@@ -25,7 +25,6 @@
 
 namespace tool_pdfpages;
 
-use core_user;
 use file_storage;
 use moodle_url;
 
@@ -131,15 +130,15 @@ class helper {
      *
      * @param \moodle_url $targeturl the target URL to reach after passing through proxy.
      * @param string $key the access key to use for Moodle user login validation.
-     * @param int $instanceid the instance ID to use for access key. {@see \tool_pdfpages\key_manager::get_instance_id}.
+     * @param int $instance the instance to use for access key. {@see \tool_pdfpages\key_manager::generate_instance}.
      *
      * @return \moodle_url
      */
-    public static function get_proxy_url(moodle_url $targeturl, string $key, int $instanceid) {
+    public static function get_proxy_url(moodle_url $targeturl, string $key, int $instance) {
         $params = [
             'url' => $targeturl->out(),
             'key' => $key,
-            'instanceid' => $instanceid
+            'instance' => $instance
         ];
 
         return new moodle_url('/admin/tool/pdfpages/index.php', $params);

--- a/classes/helper.php
+++ b/classes/helper.php
@@ -60,30 +60,6 @@ class helper {
     const CONVERTERS = ['chromium', 'wkhtmltopdf'];
 
     /**
-     * Create a user key for PDF pages.
-     *
-     * @param string $iprestriction optional IP range to restrict access to.
-     *
-     * @return string the created user key value.
-     * @throws \moodle_exception if user doesn't have permission to create key.
-     */
-    public static function create_user_key(string $iprestriction = '') : string {
-        global $USER;
-
-        require_capability('tool/pdfpages:generatepdf', \context_system::instance());
-
-        $iprestriction = !empty($iprestriction) ? $iprestriction : null;
-
-        // Tidy up old keys.
-        delete_user_key('tool/pdfpages', $USER->id);
-
-        $ttl = get_config('tool_pdfpages', 'accesskeyttl');
-        $expirationtime = !empty($ttl) ? (time() + $ttl) : (time() + MINSECS);
-
-        return create_user_key('tool/pdfpages', $USER->id, null, $iprestriction, $expirationtime);
-    }
-
-    /**
      * Get a tool_pdfpages plugin setting.
      *
      * @param string $pluginsetting the plugin setting to get value for.
@@ -155,11 +131,18 @@ class helper {
      *
      * @param \moodle_url $targeturl the target URL to reach after passing through proxy.
      * @param string $key the access key to use for Moodle user login validation.
+     * @param int $instanceid the instance ID to use for access key. {@see \tool_pdfpages\key_manager::get_instance_id}.
      *
      * @return \moodle_url
      */
-    public static function get_proxy_url(moodle_url $targeturl, string $key) {
-        return new moodle_url('/admin/tool/pdfpages/index.php', ['url' => $targeturl->out(), 'key' => $key]);
+    public static function get_proxy_url(moodle_url $targeturl, string $key, int $instanceid) {
+        $params = [
+            'url' => $targeturl->out(),
+            'key' => $key,
+            'instanceid' => $instanceid
+        ];
+
+        return new moodle_url('/admin/tool/pdfpages/index.php', $params);
     }
 
     /**
@@ -171,43 +154,5 @@ class helper {
      */
     public static function is_converter_enabled(string $convertername) {
         return array_key_exists($convertername, converter_factory::get_converters());
-    }
-
-    /**
-     * Login user with access key.
-     *
-     * @param string $key access key to use for user validation, this is required to login user and allow access of target page
-     * {@see \tool_pdfpages\helper::create_user_key}.
-     */
-    public static function login_with_key(string $key) {
-        $key = validate_user_key($key, 'tool/pdfpages', null);
-        // Destroy the single use key immediately following validation.
-        delete_user_key('tool/pdfpages', $key->userid);
-
-        self::setup_user_session($key->userid);
-    }
-
-    /**
-     * Setup a user session for headless browser use.
-     *
-     * @param int $userid the Moodle user ID.
-     *
-     * @throws \moodle_exception if the user ID was invalid.
-     */
-    protected static function setup_user_session(int $userid) {
-        global $DB;
-
-        if (!$user = $DB->get_record('user', ['id' => $userid])) {
-            throw new \moodle_exception('invaliduserid');
-        }
-
-        core_user::require_active_user($user, true, true);
-
-        enrol_check_plugins($user);
-        \core\session\manager::set_user($user);
-
-        if (!defined('USER_KEY_LOGIN')) {
-            define('USER_KEY_LOGIN', true);
-        }
     }
 }

--- a/classes/key_manager.php
+++ b/classes/key_manager.php
@@ -68,17 +68,16 @@ class key_manager {
     /**
      * Create a user key for a specific URL.
      *
+     * @param int $userid the user ID to create key for.
      * @param \moodle_url $url the URL to create user key for.
      * @param string $iprestriction optional IP range to restrict access to.
      *
      * @return string the created user key value.
      */
-    public static function create_user_key_for_url(\moodle_url $url, $iprestriction = ''): string {
-        global $USER;
-
+    public static function create_user_key_for_url(int $userid, \moodle_url $url, string $iprestriction = ''): string {
         $instance = self::generate_instance_for_url($url);
 
-        return self::create_user_key($USER->id, $instance, $iprestriction);
+        return self::create_user_key($userid, $instance, $iprestriction);
     }
 
     /**

--- a/classes/key_manager.php
+++ b/classes/key_manager.php
@@ -1,0 +1,144 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Access key manager.
+ *
+ * @package    tool_pdfpages
+ * @author     Tom Dickman <tomdickman@catalyst-au.net>
+ * @copyright  2021 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace tool_pdfpages;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Access key manager.
+ *
+ * @package    tool_pdfpages
+ * @author     Tom Dickman <tomdickman@catalyst-au.net>
+ * @copyright  2021 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class key_manager {
+
+    /**
+     * Create a user key.
+     *
+     * @param int $instanceid the instance ID to create key for.
+     * @param string $iprestriction optional IP range to restrict access to.
+     *
+     * @return string the created user key value.
+     * @throws \moodle_exception if user doesn't have permission to create key.
+     */
+    public static function create_user_key(int $instanceid, string $iprestriction = ''): string {
+        global $USER;
+
+        require_capability('tool/pdfpages:generatepdf', \context_system::instance());
+
+        $iprestriction = !empty($iprestriction) ? $iprestriction : null;
+
+        self::delete_user_key($instanceid);
+
+        $ttl = get_config('tool_pdfpages', 'accesskeyttl');
+        $expirationtime = !empty($ttl) ? (time() + $ttl) : (time() + MINSECS);
+
+        return create_user_key('tool/pdfpages', $USER->id, $instanceid, $iprestriction, $expirationtime);
+    }
+
+    /**
+     * Delete a user key.
+     *
+     * @param int $instanceid the instance ID to delete user key for.
+     *
+     * @return bool true on success.
+     */
+    public static function delete_user_key(int $instanceid): bool {
+        global $DB, $USER;
+
+        $record = [
+            'script' => 'tool/pdfpages',
+            'userid' => $USER->id,
+            'instance' => $instanceid
+        ];
+
+        return $DB->delete_records('user_private_key', $record);
+    }
+
+    /**
+     * Get a unique access key instance ID for a filename.
+     *
+     * @param string $filename the filename to get instance ID for.
+     *
+     * @return int the instance ID.
+     */
+    public static function get_instance_id(string $filename): int {
+        return (int) substr(base_convert(sha1($filename), 16, 10), 0, 18);
+    }
+
+    /**
+     * Login user with access key.
+     *
+     * @param string $key access key to use for user validation, this is required to login user and allow access of target page.
+     * @param int $instanceid the instance ID of key to login with.
+     */
+    final public static function login_with_key(string $key, int $instanceid) {
+        $key = self::validate_user_key($key, $instanceid);
+
+        // Destroy the single use key immediately following validation.
+        self::delete_user_key($instanceid);
+
+        self::setup_user_session($key->userid);
+    }
+
+    /**
+     * Setup a user session for headless browser use.
+     *
+     * @param int $userid the Moodle user ID.
+     *
+     * @throws \moodle_exception if the user ID was invalid.
+     */
+    protected static function setup_user_session(int $userid) {
+        global $DB;
+
+        if (!$user = $DB->get_record('user', ['id' => $userid])) {
+            throw new \moodle_exception('invaliduserid');
+        }
+
+        \core_user::require_active_user($user, true, true);
+
+        enrol_check_plugins($user);
+        \core\session\manager::set_user($user);
+
+        if (!defined('USER_KEY_LOGIN')) {
+            define('USER_KEY_LOGIN', true);
+        }
+    }
+
+    /**
+     * Validate a key and return record if valid.
+     *
+     * @param string $key access key to validate.
+     * @param int $instanceid the instance ID of key to validate.
+     *
+     * @return object the validated key record.
+     */
+    public static function validate_user_key(string $key, int $instanceid): object {
+        return validate_user_key($key, 'tool/pdfpages', $instanceid);
+    }
+}

--- a/classes/key_manager.php
+++ b/classes/key_manager.php
@@ -45,40 +45,40 @@ class key_manager {
     /**
      * Create a user key.
      *
+     * @param int $usedid the user ID to create key for.
      * @param int $instance the instance to create key for.
      * @param string $iprestriction optional IP range to restrict access to.
      *
      * @return string the created user key value.
      * @throws \moodle_exception if user doesn't have permission to create key.
      */
-    public static function create_user_key(int $instance, string $iprestriction = ''): string {
-        global $USER;
-
+    public static function create_user_key(int $userid, int $instance, string $iprestriction = ''): string {
         require_capability('tool/pdfpages:generatepdf', \context_system::instance());
 
         $iprestriction = !empty($iprestriction) ? $iprestriction : null;
 
-        self::delete_user_key($instance);
+        self::delete_user_keys($userid, $instance);
 
         $ttl = get_config('tool_pdfpages', 'accesskeyttl');
         $expirationtime = !empty($ttl) ? (time() + $ttl) : (time() + MINSECS);
 
-        return create_user_key(self::SCRIPT, $USER->id, $instance, $iprestriction, $expirationtime);
+        return create_user_key(self::SCRIPT, $userid, $instance, $iprestriction, $expirationtime);
     }
 
     /**
      * Delete a user key.
      *
+     * @param int $userid the user ID to delete user key for.
      * @param int $instance the instance to delete user key for.
      *
      * @return bool true on success.
      */
-    public static function delete_user_key(int $instance): bool {
-        global $DB, $USER;
+    public static function delete_user_keys(int $userid, int $instance): bool {
+        global $DB;
 
         $record = [
             'script' => self::SCRIPT,
-            'userid' => $USER->id,
+            'userid' => $userid,
             'instance' => $instance
         ];
 

--- a/classes/key_manager.php
+++ b/classes/key_manager.php
@@ -45,7 +45,7 @@ class key_manager {
     /**
      * Create a user key.
      *
-     * @param int $usedid the user ID to create key for.
+     * @param int $userid the user ID to create key for.
      * @param int $instance the instance to create key for.
      * @param string $iprestriction optional IP range to restrict access to.
      *

--- a/classes/key_manager.php
+++ b/classes/key_manager.php
@@ -38,6 +38,11 @@ defined('MOODLE_INTERNAL') || die();
 class key_manager {
 
     /**
+     * The script name to associate with keys.
+     */
+    const SCRIPT = 'tool/pdfpages';
+
+    /**
      * Create a user key.
      *
      * @param int $instance the instance to create key for.
@@ -58,7 +63,7 @@ class key_manager {
         $ttl = get_config('tool_pdfpages', 'accesskeyttl');
         $expirationtime = !empty($ttl) ? (time() + $ttl) : (time() + MINSECS);
 
-        return create_user_key('tool/pdfpages', $USER->id, $instance, $iprestriction, $expirationtime);
+        return create_user_key(self::SCRIPT, $USER->id, $instance, $iprestriction, $expirationtime);
     }
 
     /**
@@ -72,7 +77,7 @@ class key_manager {
         global $DB, $USER;
 
         $record = [
-            'script' => 'tool/pdfpages',
+            'script' => self::SCRIPT,
             'userid' => $USER->id,
             'instance' => $instance
         ];
@@ -100,6 +105,6 @@ class key_manager {
      * @return object the validated key record.
      */
     public static function validate_user_key(string $key, int $instance): object {
-        return validate_user_key($key, 'tool/pdfpages', $instance);
+        return validate_user_key($key, self::SCRIPT, $instance);
     }
 }

--- a/classes/login_manager.php
+++ b/classes/login_manager.php
@@ -1,0 +1,80 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Manager for user logins to conduct conversions.
+ *
+ * @package    tool_pdfpages
+ * @author     Tom Dickman <tomdickman@catalyst-au.net>
+ * @copyright  2021 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace tool_pdfpages;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Manager for user logins to conduct conversions.
+ *
+ * @package    tool_pdfpages
+ * @author     Tom Dickman <tomdickman@catalyst-au.net>
+ * @copyright  2021 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class login_manager {
+
+    /**
+     * Login user with access key.
+     *
+     * @param string $key access key to use for user validation, this is required to login user and allow access of target page.
+     * @param int $instance the instance of key to login with.
+     */
+    final public static function login_with_key(string $key, int $instance) {
+        $key = key_manager::validate_user_key($key, $instance);
+
+        // Destroy the single use key immediately following validation.
+        key_manager::delete_user_key($instance);
+
+        self::setup_user_session($key->userid);
+    }
+
+    /**
+     * Setup a user session for headless browser use.
+     *
+     * @param int $userid the Moodle user ID.
+     *
+     * @throws \moodle_exception if the user ID was invalid.
+     */
+    protected static function setup_user_session(int $userid) {
+        global $DB;
+
+        $user = $DB->get_record('user', ['id' => $userid]);
+
+        if ($user === false) {
+            throw new \moodle_exception('invaliduserid');
+        }
+
+        \core_user::require_active_user($user, true, true);
+
+        enrol_check_plugins($user);
+        \core\session\manager::set_user($user);
+
+        if (!defined('USER_KEY_LOGIN')) {
+            define('USER_KEY_LOGIN', true);
+        }
+    }
+}

--- a/classes/login_manager.php
+++ b/classes/login_manager.php
@@ -47,7 +47,7 @@ class login_manager {
         $key = key_manager::validate_user_key($key, $instance);
 
         // Destroy the single use key immediately following validation.
-        key_manager::delete_user_key($instance);
+        key_manager::delete_user_keys($key->userid, $instance);
 
         self::setup_user_session($key->userid);
     }

--- a/classes/login_manager.php
+++ b/classes/login_manager.php
@@ -41,13 +41,13 @@ class login_manager {
      * Login user with access key.
      *
      * @param string $key access key to use for user validation, this is required to login user and allow access of target page.
-     * @param int $instance the instance of key to login with.
+     * @param \moodle_url $url the Moodle URL to login for with key.
      */
-    final public static function login_with_key(string $key, int $instance) {
-        $key = key_manager::validate_user_key($key, $instance);
+    final public static function login_with_key(string $key, \moodle_url $url) {
+        $key = key_manager::validate_user_key_for_url($key, $url);
 
         // Destroy the single use key immediately following validation.
-        key_manager::delete_user_keys($key->userid, $instance);
+        key_manager::delete_user_keys_for_url($key->userid, $url);
 
         self::setup_user_session($key->userid);
     }

--- a/index.php
+++ b/index.php
@@ -27,16 +27,17 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-use tool_pdfpages\helper;
+use tool_pdfpages\key_manager;
 
 require_once(__DIR__ . '/../../../config.php');
 
 $targeturl = required_param('url', PARAM_URL);
 $key = required_param('key', PARAM_ALPHANUM);
+$instanceid = required_param('instanceid', PARAM_INT);
 
 $url = new moodle_url($targeturl);
 
-helper::login_with_key($key);
+key_manager::login_with_key($key, $instanceid);
 
 require_capability('tool/pdfpages:generatepdf', \context_system::instance());
 

--- a/index.php
+++ b/index.php
@@ -33,11 +33,10 @@ require_once(__DIR__ . '/../../../config.php');
 
 $targeturl = required_param('url', PARAM_URL);
 $key = required_param('key', PARAM_ALPHANUM);
-$instance = required_param('instance', PARAM_INT);
 
 $url = new moodle_url($targeturl);
 
-login_manager::login_with_key($key, $instance);
+login_manager::login_with_key($key, $url);
 
 require_capability('tool/pdfpages:generatepdf', \context_system::instance());
 

--- a/index.php
+++ b/index.php
@@ -27,17 +27,17 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-use tool_pdfpages\key_manager;
+use tool_pdfpages\login_manager;
 
 require_once(__DIR__ . '/../../../config.php');
 
 $targeturl = required_param('url', PARAM_URL);
 $key = required_param('key', PARAM_ALPHANUM);
-$instanceid = required_param('instanceid', PARAM_INT);
+$instance = required_param('instance', PARAM_INT);
 
 $url = new moodle_url($targeturl);
 
-key_manager::login_with_key($key, $instanceid);
+login_manager::login_with_key($key, $instance);
 
 require_capability('tool/pdfpages:generatepdf', \context_system::instance());
 

--- a/tests/helper_test.php
+++ b/tests/helper_test.php
@@ -123,13 +123,13 @@ class tool_pdfpages_helper_test extends advanced_testcase {
         $course = $this->getDataGenerator()->create_course();
 
         $url = new moodle_url("/course/view.php?id={$course->id}");
-        $instanceid = 123456789123456789;
-        $key = key_manager::create_user_key($instanceid);
+        $instance = 123456789123456789;
+        $key = key_manager::create_user_key($instance);
 
-        $actual = helper::get_proxy_url($url, $key, $instanceid);
+        $actual = helper::get_proxy_url($url, $key, $instance);
         $this->assertInstanceOf(moodle_url::class, $actual);
         $this->assertEquals($url->out(), $actual->get_param('url'));
         $this->assertEquals($key, $actual->get_param('key'));
-        $this->assertEquals($instanceid, $actual->get_param('instanceid'));
+        $this->assertEquals($instance, $actual->get_param('instance'));
     }
 }

--- a/tests/helper_test.php
+++ b/tests/helper_test.php
@@ -118,13 +118,19 @@ class tool_pdfpages_helper_test extends advanced_testcase {
     public function test_get_proxy_url() {
         $this->resetAfterTest();
 
-        $this->setAdminUser();
+        $user = $this->getDataGenerator()->create_user();
+        $this->setUser($user);
+
+        // Assign the user a role with the capability to generate PDFs.
+        $roleid = $this->getDataGenerator()->create_role();
+        assign_capability('tool/pdfpages:generatepdf', CAP_ALLOW, $roleid, context_system::instance());
+        $this->getDataGenerator()->role_assign($roleid, $user->id);
 
         $course = $this->getDataGenerator()->create_course();
 
         $url = new moodle_url("/course/view.php?id={$course->id}");
         $instance = 123456789123456789;
-        $key = key_manager::create_user_key($instance);
+        $key = key_manager::create_user_key($user->id, $instance);
 
         $actual = helper::get_proxy_url($url, $key, $instance);
         $this->assertInstanceOf(moodle_url::class, $actual);

--- a/tests/helper_test.php
+++ b/tests/helper_test.php
@@ -129,13 +129,11 @@ class tool_pdfpages_helper_test extends advanced_testcase {
         $course = $this->getDataGenerator()->create_course();
 
         $url = new moodle_url("/course/view.php?id={$course->id}");
-        $instance = 123456789123456789;
-        $key = key_manager::create_user_key($user->id, $instance);
+        $key = key_manager::create_user_key_for_url($url);
 
-        $actual = helper::get_proxy_url($url, $key, $instance);
+        $actual = helper::get_proxy_url($url, $key);
         $this->assertInstanceOf(moodle_url::class, $actual);
         $this->assertEquals($url->out(), $actual->get_param('url'));
         $this->assertEquals($key, $actual->get_param('key'));
-        $this->assertEquals($instance, $actual->get_param('instance'));
     }
 }

--- a/tests/helper_test.php
+++ b/tests/helper_test.php
@@ -129,7 +129,7 @@ class tool_pdfpages_helper_test extends advanced_testcase {
         $course = $this->getDataGenerator()->create_course();
 
         $url = new moodle_url("/course/view.php?id={$course->id}");
-        $key = key_manager::create_user_key_for_url($url);
+        $key = key_manager::create_user_key_for_url($user->id, $url);
 
         $actual = helper::get_proxy_url($url, $key);
         $this->assertInstanceOf(moodle_url::class, $actual);

--- a/tests/helper_test.php
+++ b/tests/helper_test.php
@@ -24,6 +24,7 @@
  */
 
 use tool_pdfpages\helper;
+use tool_pdfpages\key_manager;
 
 defined('MOODLE_INTERNAL') || die();
 
@@ -36,82 +37,6 @@ defined('MOODLE_INTERNAL') || die();
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class tool_pdfpages_helper_test extends advanced_testcase {
-
-    /**
-     * Test that user keys are created correctly.
-     */
-    public function test_create_user_key() {
-        $this->resetAfterTest();
-
-        set_config('accesskeyttl', 60, 'tool_pdfpages');
-
-        $user = $this->getDataGenerator()->create_user();
-
-        // Assign the user a role with the capability to generate PDFs.
-        $roleid = $this->getDataGenerator()->create_role();
-        assign_capability('tool/pdfpages:generatepdf', CAP_ALLOW, $roleid, context_system::instance());
-        $this->getDataGenerator()->role_assign($roleid, $user->id);
-
-        $this->setUser($user);
-
-        $actual = helper::create_user_key();
-
-        $key = validate_user_key($actual, 'tool/pdfpages', null);
-        $this->assertEquals('tool/pdfpages', $key->script);
-        $this->assertEquals($user->id, $key->userid);
-    }
-
-    /**
-     * Test that key cannot be created if user doesn't have capability to create keys.
-     */
-    public function test_create_key_no_permission() {
-        $this->resetAfterTest();
-
-        set_config('accesskeyttl', 60, 'tool_pdfpages');
-
-        $user = $this->getDataGenerator()->create_user();
-
-        $this->setUser($user);
-
-        $this->expectException(moodle_exception::class);
-        $this->expectExceptionMessage('Sorry, but you do not currently have permissions to do that (Generate a PDF from a Moodle URL).');
-        helper::create_user_key();
-    }
-
-    /**
-     * Test that IP restrictions applied to access keys function correctly.
-     */
-    public function test_create_user_key_iprestriction() {
-        $this->resetAfterTest();
-
-        set_config('accesskeyttl', 60, 'tool_pdfpages');
-
-        $user = $this->getDataGenerator()->create_user();
-        $this->setUser($user);
-
-        // Assign the user a role with the capability to generate PDFs.
-        $roleid = $this->getDataGenerator()->create_role();
-        assign_capability('tool/pdfpages:generatepdf', CAP_ALLOW, $roleid, context_system::instance());
-        $this->getDataGenerator()->role_assign($roleid, $user->id);
-
-        $actual = helper::create_user_key('123.121.234.0/30');
-
-        // Spoof server remote address matching CIDR IP restriction.
-        $_SERVER['REMOTE_ADDR'] = '123.121.234.1';
-
-        // Should only validate if current remote address is within the specified IP restriction range.
-        $key = validate_user_key($actual, 'tool/pdfpages', null);
-        $this->assertEquals('tool/pdfpages', $key->script);
-        $this->assertEquals($user->id, $key->userid);
-        $this->assertEquals('123.121.234.0/30', $key->iprestriction);
-
-        // Spoof server remote address not matching CIDR IP restriction.
-        $_SERVER['REMOTE_ADDR'] = '123.121.234.4';
-
-        $this->expectException(moodle_exception::class);
-        $this->expectExceptionMessage('Client IP address mismatch');
-        validate_user_key($actual, 'tool/pdfpages', null);
-    }
 
     /**
      * Test getting a plugin setting value.
@@ -198,52 +123,13 @@ class tool_pdfpages_helper_test extends advanced_testcase {
         $course = $this->getDataGenerator()->create_course();
 
         $url = new moodle_url("/course/view.php?id={$course->id}");
-        $key = helper::create_user_key();
+        $instanceid = 123456789123456789;
+        $key = key_manager::create_user_key($instanceid);
 
-        $actual = helper::get_proxy_url($url, $key);
+        $actual = helper::get_proxy_url($url, $key, $instanceid);
         $this->assertInstanceOf(moodle_url::class, $actual);
         $this->assertEquals($url->out(), $actual->get_param('url'));
         $this->assertEquals($key, $actual->get_param('key'));
-    }
-
-    /**
-     * Test that user session is correctly created with a key login.
-     */
-    public function test_login_with_key() {
-        global $DB, $USER;
-
-        $this->resetAfterTest();
-
-        $user = $this->getDataGenerator()->create_user();
-        $this->setUser($user);
-
-        // Assign the user a role with the capability to generate PDFs.
-        $roleid = $this->getDataGenerator()->create_role();
-        assign_capability('tool/pdfpages:generatepdf', CAP_ALLOW, $roleid, context_system::instance());
-        $this->getDataGenerator()->role_assign($roleid, $user->id);
-
-        $key = helper::create_user_key();
-
-        // Check that the key record exists and is for the correct user.
-        $record = $DB->get_record('user_private_key', ['script' => 'tool/pdfpages', 'value' => $key]);
-        $this->assertEquals($user->id, $record->userid);
-
-        // Emulate using new browser without an existing session or login.
-        \core\session\manager::kill_all_sessions();
-        $this->setUser();
-
-        helper::login_with_key($key);
-
-        // Login with key should correctly set up session and log in user.
-        $this->assertEquals($user->id, $USER->id);
-        $this->assertEquals($user->id, $_SESSION['USER']->id);
-
-        // Create a fake key.
-        $key = md5($user->id . '_' . time() . random_string(40));
-
-        // Invalid key should not allow login.
-        $this->expectException(moodle_exception::class);
-        $this->expectExceptionMessage('Incorrect key');
-        helper::login_with_key($key);
+        $this->assertEquals($instanceid, $actual->get_param('instanceid'));
     }
 }

--- a/tests/key_manager_test.php
+++ b/tests/key_manager_test.php
@@ -74,7 +74,7 @@ class key_manager_test extends advanced_testcase {
 
         $url = new moodle_url('/my/index.php');
 
-        $actual = key_manager::create_user_key_for_url($url);
+        $actual = key_manager::create_user_key_for_url($user->id, $url);
 
         $instance = key_manager::generate_instance_for_url($url);
         $key = validate_user_key($actual, 'tool/pdfpages', $instance);
@@ -99,7 +99,7 @@ class key_manager_test extends advanced_testcase {
         $this->expectException(moodle_exception::class);
         $this->expectExceptionMessage('Sorry, but you do not currently have permissions to do that ' .
             '(Generate a PDF from a Moodle URL).');
-        key_manager::create_user_key_for_url($url);
+        key_manager::create_user_key_for_url($user->id, $url);
     }
 
     /**
@@ -120,7 +120,7 @@ class key_manager_test extends advanced_testcase {
 
         $url = new moodle_url('/my/index.php');
 
-        $actual = key_manager::create_user_key_for_url($url, '123.121.234.0/30');
+        $actual = key_manager::create_user_key_for_url($user->id, $url, '123.121.234.0/30');
 
         // Spoof server remote address matching CIDR IP restriction.
         $_SERVER['REMOTE_ADDR'] = '123.121.234.1';
@@ -158,7 +158,7 @@ class key_manager_test extends advanced_testcase {
         $this->getDataGenerator()->role_assign($roleid, $user->id);
 
         $url = new moodle_url('/my/index.php');
-        $key = key_manager::create_user_key_for_url($url);
+        $key = key_manager::create_user_key_for_url($user->id, $url);
 
         $conditions = [
             'value' => $key,

--- a/tests/key_manager_test.php
+++ b/tests/key_manager_test.php
@@ -1,0 +1,210 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Tests for key manager.
+ *
+ * @package    tool_pdfpages
+ * @author     Tom Dickman <tomdickman@catalyst-au.net>
+ * @copyright  2021 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+use tool_pdfpages\key_manager;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Tests for key manager.
+ *
+ * @package    tool_pdfpages
+ * @author     Tom Dickman <tomdickman@catalyst-au.net>
+ * @copyright  2021 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class key_manager_test extends advanced_testcase {
+
+    /**
+     * Test getting the instance ID for a filename.
+     */
+    public function test_get_instance_id() {
+        $filename = 'test.pdf';
+
+        $actual = key_manager::get_instance_id($filename);
+
+        // Should have no more that 19 digits, due to field length constraints in DB.
+        $this->assertLessThanOrEqual(19, strlen($actual));
+
+        // Should match a SHA1 hash of the filename converted to base 10 and shortened to fit field constraints.
+        $sha1 = sha1($filename);
+        $base10 = base_convert($sha1, 16, 10);
+        $expected = (int) substr($base10, 0, 18);
+        $this->assertIsInt($actual);
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * Test that user keys are created correctly.
+     */
+    public function test_create_user_key() {
+        $this->resetAfterTest();
+
+        set_config('accesskeyttl', 60, 'tool_pdfpages');
+
+        $user = $this->getDataGenerator()->create_user();
+
+        // Assign the user a role with the capability to generate PDFs.
+        $roleid = $this->getDataGenerator()->create_role();
+        assign_capability('tool/pdfpages:generatepdf', CAP_ALLOW, $roleid, context_system::instance());
+        $this->getDataGenerator()->role_assign($roleid, $user->id);
+
+        $this->setUser($user);
+
+        $instanceid = 123456789101112131;
+        $actual = key_manager::create_user_key($instanceid);
+
+        $key = validate_user_key($actual, 'tool/pdfpages', $instanceid);
+        $this->assertEquals('tool/pdfpages', $key->script);
+        $this->assertEquals($user->id, $key->userid);
+        $this->assertEquals($instanceid, $key->instance);
+    }
+
+    /**
+     * Test that key cannot be created if user doesn't have capability to create keys.
+     */
+    public function test_create_key_no_permission() {
+        $this->resetAfterTest();
+
+        set_config('accesskeyttl', 60, 'tool_pdfpages');
+
+        $user = $this->getDataGenerator()->create_user();
+
+        $this->setUser($user);
+
+        $this->expectException(moodle_exception::class);
+        $this->expectExceptionMessage('Sorry, but you do not currently have permissions to do that ' .
+            '(Generate a PDF from a Moodle URL).');
+        key_manager::create_user_key(123456789101112131);
+    }
+
+    /**
+     * Test that IP restrictions applied to access keys function correctly.
+     */
+    public function test_create_user_key_iprestriction() {
+        $this->resetAfterTest();
+
+        set_config('accesskeyttl', 60, 'tool_pdfpages');
+
+        $user = $this->getDataGenerator()->create_user();
+        $this->setUser($user);
+
+        // Assign the user a role with the capability to generate PDFs.
+        $roleid = $this->getDataGenerator()->create_role();
+        assign_capability('tool/pdfpages:generatepdf', CAP_ALLOW, $roleid, context_system::instance());
+        $this->getDataGenerator()->role_assign($roleid, $user->id);
+
+        $instanceid = 123456789101112131;
+        $actual = key_manager::create_user_key($instanceid, '123.121.234.0/30');
+
+        // Spoof server remote address matching CIDR IP restriction.
+        $_SERVER['REMOTE_ADDR'] = '123.121.234.1';
+
+        // Should only validate if current remote address is within the specified IP restriction range.
+        $key = validate_user_key($actual, 'tool/pdfpages', $instanceid);
+        $this->assertEquals('tool/pdfpages', $key->script);
+        $this->assertEquals($user->id, $key->userid);
+        $this->assertEquals($instanceid, $key->instance);
+        $this->assertEquals('123.121.234.0/30', $key->iprestriction);
+
+        // Spoof server remote address not matching CIDR IP restriction.
+        $_SERVER['REMOTE_ADDR'] = '123.121.234.4';
+
+        $this->expectException(moodle_exception::class);
+        $this->expectExceptionMessage('Client IP address mismatch');
+        validate_user_key($actual, 'tool/pdfpages', $instanceid);
+    }
+
+    /**
+     * Test that user keys are correctly deleted.
+     */
+    public function test_delete_user_key() {
+        global $DB, $USER;
+
+        $this->resetAfterTest();
+
+        // Set admin user so key can be generated.
+        $this->setAdminUser();
+
+        $instanceid = 123456789123456789;
+        $key = key_manager::create_user_key($instanceid);
+
+        $conditions = [
+            'value' => $key,
+            'script' => 'tool/pdfpages',
+            'instance' => $instanceid,
+            'userid' => $USER->id
+        ];
+
+        // Check that key is created in DB.
+        $this->assertNotFalse($DB->get_record('user_private_key', $conditions));
+
+        // Key record should be deleted.
+        key_manager::delete_user_key($instanceid);
+        $this->assertFalse($DB->get_record('user_private_key', $conditions));
+    }
+
+    /**
+     * Test that user session is correctly created with a key login.
+     */
+    public function test_login_with_key() {
+        global $DB, $USER;
+
+        $this->resetAfterTest();
+
+        $user = $this->getDataGenerator()->create_user();
+        $this->setUser($user);
+
+        // Assign the user a role with the capability to generate PDFs.
+        $roleid = $this->getDataGenerator()->create_role();
+        assign_capability('tool/pdfpages:generatepdf', CAP_ALLOW, $roleid, context_system::instance());
+        $this->getDataGenerator()->role_assign($roleid, $user->id);
+
+        $instanceid = 123456789123456789;
+        $key = key_manager::create_user_key($instanceid);
+
+        // Check that the key record exists and is for the correct user.
+        $record = $DB->get_record('user_private_key', ['script' => 'tool/pdfpages', 'value' => $key]);
+        $this->assertEquals($user->id, $record->userid);
+
+        // Emulate using new browser without an existing session or login.
+        \core\session\manager::kill_all_sessions();
+        $this->setUser();
+
+        key_manager::login_with_key($key, $instanceid);
+
+        // Login with key should correctly set up session and log in user.
+        $this->assertEquals($user->id, $USER->id);
+        $this->assertEquals($user->id, $_SESSION['USER']->id);
+
+        // Create a fake key.
+        $key = md5($user->id . '_' . time() . random_string(40));
+
+        // Invalid key should not allow login.
+        $this->expectException(moodle_exception::class);
+        $this->expectExceptionMessage('Incorrect key');
+        key_manager::login_with_key($key, $instanceid);
+    }
+}

--- a/tests/login_manager_test.php
+++ b/tests/login_manager_test.php
@@ -54,8 +54,8 @@ class login_manager_test extends advanced_testcase {
         assign_capability('tool/pdfpages:generatepdf', CAP_ALLOW, $roleid, context_system::instance());
         $this->getDataGenerator()->role_assign($roleid, $user->id);
 
-        $instance = 123456789123456789;
-        $key = key_manager::create_user_key($user->id, $instance);
+        $url = new moodle_url('/my/index.php');
+        $key = key_manager::create_user_key_for_url($url);
 
         // Check that the key record exists and is for the correct user.
         $record = $DB->get_record('user_private_key', ['script' => 'tool/pdfpages', 'value' => $key]);
@@ -65,7 +65,7 @@ class login_manager_test extends advanced_testcase {
         \core\session\manager::kill_all_sessions();
         $this->setUser();
 
-        login_manager::login_with_key($key, $instance);
+        login_manager::login_with_key($key, $url);
 
         // Login with key should correctly set up session and log in user.
         $this->assertEquals($user->id, $USER->id);
@@ -77,7 +77,7 @@ class login_manager_test extends advanced_testcase {
         // Invalid key should not allow login.
         $this->expectException(moodle_exception::class);
         $this->expectExceptionMessage('Incorrect key');
-        login_manager::login_with_key($key, $instance);
+        login_manager::login_with_key($key, $url);
     }
 
 }

--- a/tests/login_manager_test.php
+++ b/tests/login_manager_test.php
@@ -1,0 +1,83 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Tests for login manager.
+ *
+ * @package    tool_pdfpages
+ * @author     Tom Dickman <tomdickman@catalyst-au.net>
+ * @copyright  2021 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+use tool_pdfpages\key_manager;
+use tool_pdfpages\login_manager;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Tests for login manager.
+ *
+ * @package    tool_pdfpages
+ * @author     Tom Dickman <tomdickman@catalyst-au.net>
+ * @copyright  2021 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class login_manager_test extends advanced_testcase {
+
+    /**
+     * Test that user session is correctly created with a key login.
+     */
+    public function test_login_with_key() {
+        global $DB, $USER;
+
+        $this->resetAfterTest();
+
+        $user = $this->getDataGenerator()->create_user();
+        $this->setUser($user);
+
+        // Assign the user a role with the capability to generate PDFs.
+        $roleid = $this->getDataGenerator()->create_role();
+        assign_capability('tool/pdfpages:generatepdf', CAP_ALLOW, $roleid, context_system::instance());
+        $this->getDataGenerator()->role_assign($roleid, $user->id);
+
+        $instance = 123456789123456789;
+        $key = key_manager::create_user_key($instance);
+
+        // Check that the key record exists and is for the correct user.
+        $record = $DB->get_record('user_private_key', ['script' => 'tool/pdfpages', 'value' => $key]);
+        $this->assertEquals($user->id, $record->userid);
+
+        // Emulate using new browser without an existing session or login.
+        \core\session\manager::kill_all_sessions();
+        $this->setUser();
+
+        login_manager::login_with_key($key, $instance);
+
+        // Login with key should correctly set up session and log in user.
+        $this->assertEquals($user->id, $USER->id);
+        $this->assertEquals($user->id, $_SESSION['USER']->id);
+
+        // Create a fake key.
+        $key = md5($user->id . '_' . time() . random_string(40));
+
+        // Invalid key should not allow login.
+        $this->expectException(moodle_exception::class);
+        $this->expectExceptionMessage('Incorrect key');
+        login_manager::login_with_key($key, $instance);
+    }
+
+}

--- a/tests/login_manager_test.php
+++ b/tests/login_manager_test.php
@@ -55,7 +55,7 @@ class login_manager_test extends advanced_testcase {
         $this->getDataGenerator()->role_assign($roleid, $user->id);
 
         $url = new moodle_url('/my/index.php');
-        $key = key_manager::create_user_key_for_url($url);
+        $key = key_manager::create_user_key_for_url($user->id, $url);
 
         // Check that the key record exists and is for the correct user.
         $record = $DB->get_record('user_private_key', ['script' => 'tool/pdfpages', 'value' => $key]);

--- a/tests/login_manager_test.php
+++ b/tests/login_manager_test.php
@@ -55,7 +55,7 @@ class login_manager_test extends advanced_testcase {
         $this->getDataGenerator()->role_assign($roleid, $user->id);
 
         $instance = 123456789123456789;
-        $key = key_manager::create_user_key($instance);
+        $key = key_manager::create_user_key($user->id, $instance);
 
         // Check that the key record exists and is for the correct user.
         $record = $DB->get_record('user_private_key', ['script' => 'tool/pdfpages', 'value' => $key]);

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2021031701;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2021032201;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2020061504;        // Requires this Moodle version.
 $plugin->component = 'tool_pdfpages';  // Full name of the plugin (used for diagnostics).
 $plugin->maturity = MATURITY_BETA;


### PR DESCRIPTION
Race conditions are evident as a result of running multiple
conversions in parallel through adhoc tasks, this results in one or
more conversions failing due to an access key being deleted for a
user when still in use.

Attach an instance ID to access keys and abstract the user key
handling into a key manager, so now only the key for a particular
filename is deleted, not all keys for user.

Closes #23 